### PR TITLE
Empty current lap when pitting

### DIFF
--- a/src/app/services/standings.service.ts
+++ b/src/app/services/standings.service.ts
@@ -150,6 +150,11 @@ export class StandingsService {
             processed.currentLap.sector1 = entry.currentSectorTime1;
         }
 
+        // clear the drivers current lap if they enter the pits
+        if (processed.pitting) {
+            processed.currentLap = this._getEmptyLap();
+        }
+
         // colour, flag and focuseddriver
         processed.colour = this._getTeamColour(entry.carClass);
         processed.flag = this._getDriverFlag(entry.driverName);


### PR DESCRIPTION
When a driver enters the pits, their timing is cleared but their states are maintained.

![4d55cfa4e03faaa4ff3b07b3c3c08293-png](https://user-images.githubusercontent.com/26087058/49470861-35712d00-f803-11e8-9c42-fb7e92eb5969.jpg)
