### PR TITLE
#42 When in a timed session, show 'NO TIME' instead of nothing

### DIFF
--- a/src/app/components/default/tower/tower.component.html
+++ b/src/app/components/default/tower/tower.component.html
@@ -9,11 +9,14 @@
         </div>
 
         <!-- Gap to fastest -->
-        <div class="entry__gap" *ngIf="mode === 'FASTEST_LAP_GAP' && entry.bestLapTime !== -1">
-            <span *ngIf="entry.position === 1">
+        <div class="entry__gap" *ngIf="mode === 'FASTEST_LAP_GAP'">
+            <span *ngIf="entry.bestLapTime === -1">
+                NO TIME
+            </span>
+            <span *ngIf="entry.position === 1 && entry.bestLapTime !== -1">
                 {{ entry.bestLapTime | minutesAndSeconds:true:false }}
             </span>
-            <span *ngIf="entry.position > 1">
+            <span *ngIf="entry.position > 1 && entry.bestLapTime !== -1">
                 {{ entry.gapToLeader }}
             </span>
         </div>


### PR DESCRIPTION
Github issue: https://github.com/KChadwick96/rFactor-2-Overlay/issues/42

When in a timed session, show 'NO TIME' instead of nothing
