### PR TITLE
Issue #47 - Session best sectors fixed

### DIFF
--- a/src/app/interfaces.ts
+++ b/src/app/interfaces.ts
@@ -52,6 +52,12 @@ export interface SectorFlags {
     sector3: SectorFlag;
 }
 
+export interface Sectors {
+    sector1: number;
+    sector2: number;
+    sector3: number;
+}
+
 export interface GapEvent {
     state: State;
     gap: string;

--- a/src/app/services/standings.service.ts
+++ b/src/app/services/standings.service.ts
@@ -16,7 +16,7 @@ export class StandingsService {
     private _overallBestLap: Lap;
     private _focusedDriver: ProcessedEntry;
     private _sectorFlags: SectorFlags;
-    private _overallBestSectors: Sectors;
+    private _overallBestSectors: Array<Sectors>;
 
     get currentStandings(): Array<ProcessedEntry> {
         return this._currentStandings;
@@ -30,7 +30,7 @@ export class StandingsService {
         return this._overallBestLap;
     }
 
-    get overallBestSectors(): Sectors {
+    get overallBestSectors(): Array<Sectors> {
         return this._overallBestSectors;
     }
 
@@ -77,6 +77,8 @@ export class StandingsService {
         this._currentStandings = [];
         this._focusedDriver = null;
         this._overallBestLap = null;
+        this._overallBestSectors = [];
+
     }
 
     /**
@@ -249,14 +251,14 @@ export class StandingsService {
      * @param personalBest - Personal Best to compare against
      */
     _getLapState(sectorKey: string, current: number, personalBest: Lap): State {
+        if (sectorKey.includes('sector')) {
+            if (!this._overallBestSectors[sectorKey] || current < this._overallBestSectors[sectorKey]) {
+                this._setFastestSector(sectorKey, current);
+                return State.SessionBest;
+            }
+        }
 
-        // check if sector 1, 2, 3 or total in order to determine whether or not
-        // to check against overallBestLap(total) or overBestSectors(1,2 or 3)
-
-        if (!this._overallBestLap || current < this._overallBestLap[sectorKey]) {
-            // need to update overallBestSectors here with current
-            this._setFastestSector(sectorKey, current);
-
+        if (sectorKey.includes('total') && (!this._overallBestLap || current < this._overallBestLap[sectorKey])) {
             return State.SessionBest;
 
         } else if (!personalBest || current < personalBest[sectorKey]) {

--- a/src/app/services/standings.service.ts
+++ b/src/app/services/standings.service.ts
@@ -3,7 +3,7 @@ import { sortBy, isEmpty } from 'lodash';
 
 import { ConfigService } from './config.service';
 import { LiveService } from './live.service';
-import { Entry, ProcessedEntry, Lap, State, SectorFlag, SectorFlags } from '../interfaces';
+import { Entry, ProcessedEntry, Lap, State, SectorFlag, SectorFlags, Sectors } from '../interfaces';
 
 @Injectable()
 export class StandingsService {
@@ -16,7 +16,7 @@ export class StandingsService {
     private _overallBestLap: Lap;
     private _focusedDriver: ProcessedEntry;
     private _sectorFlags: SectorFlags;
-
+    private _overallBestSectors: Sectors;
 
     get currentStandings(): Array<ProcessedEntry> {
         return this._currentStandings;
@@ -28,6 +28,10 @@ export class StandingsService {
 
     get overallBestLap(): Lap {
         return this._overallBestLap;
+    }
+
+    get overallBestSectors(): Sectors {
+        return this._overallBestSectors;
     }
 
     get focusedDriver(): ProcessedEntry {
@@ -120,6 +124,7 @@ export class StandingsService {
             };
 
             this._sessionFastestLapCheck(lastLap);
+            this._sessionFastestSectorCheck();
 
             processed.currentLap = this._getEmptyLap();
         }
@@ -274,6 +279,17 @@ export class StandingsService {
         if (isEmpty(this._overallBestLap) || this._overallBestLap.total > lap.total) {
             this._overallBestLap = lap;
         }
+    }
+
+    /**
+     * If sector is fastest overall, then update best sector array
+     * */
+    _sessionFastestSectorCheck() {
+        this._overallBestSectors = {
+            sector1: 20.356,
+            sector2: 27.482,
+            sector3: 29.172
+        };
     }
 
     /**

--- a/src/app/services/standings.service.ts
+++ b/src/app/services/standings.service.ts
@@ -16,7 +16,7 @@ export class StandingsService {
     private _overallBestLap: Lap;
     private _focusedDriver: ProcessedEntry;
     private _sectorFlags: SectorFlags;
-    private _overallBestSectors: Array<Sectors>;
+    private _overallBestSectors: Sectors;
 
     get currentStandings(): Array<ProcessedEntry> {
         return this._currentStandings;
@@ -30,7 +30,7 @@ export class StandingsService {
         return this._overallBestLap;
     }
 
-    get overallBestSectors(): Array<Sectors> {
+    get overallBestSectors(): Sectors {
         return this._overallBestSectors;
     }
 
@@ -77,7 +77,7 @@ export class StandingsService {
         this._currentStandings = [];
         this._focusedDriver = null;
         this._overallBestLap = null;
-        this._overallBestSectors = [];
+        this._overallBestSectors = {sector1: null, sector2: null, sector3: null};
 
     }
 
@@ -145,6 +145,7 @@ export class StandingsService {
             const gap = (gapValue > 0 ? '+' : '') + gapValue.toFixed(3);
 
             const sector2RealTime = entry.currentSectorTime2 - entry.currentSectorTime1;
+
             // gap state + and assign to entry
             const state = this._getSectorState('sector2', sector2RealTime, previousEntry.bestLap);
             processed.gapEvent = {state, gap};

--- a/src/app/services/standings.service.ts
+++ b/src/app/services/standings.service.ts
@@ -124,7 +124,6 @@ export class StandingsService {
             };
 
             this._sessionFastestLapCheck(lastLap);
-            this._sessionFastestSectorCheck();
 
             processed.currentLap = this._getEmptyLap();
         }
@@ -250,8 +249,16 @@ export class StandingsService {
      * @param personalBest - Personal Best to compare against
      */
     _getLapState(sectorKey: string, current: number, personalBest: Lap): State {
+
+        // check if sector 1, 2, 3 or total in order to determine whether or not
+        // to check against overallBestLap(total) or overBestSectors(1,2 or 3)
+
         if (!this._overallBestLap || current < this._overallBestLap[sectorKey]) {
+            // need to update overallBestSectors here with current
+            this._setFastestSector(sectorKey, current);
+
             return State.SessionBest;
+
         } else if (!personalBest || current < personalBest[sectorKey]) {
             return State.PersonalBest;
         } else {
@@ -282,14 +289,14 @@ export class StandingsService {
     }
 
     /**
-     * If sector is fastest overall, then update best sector array
-     * */
-    _sessionFastestSectorCheck() {
-        this._overallBestSectors = {
-            sector1: 20.356,
-            sector2: 27.482,
-            sector3: 29.172
-        };
+     * Update sector with new best time
+     * @param sectorKey - Sector to evaluate
+     * @param sectorTime - Sector time in seconds
+     */
+    _setFastestSector(sectorKey: string, sectorTime: number, ) {
+        if (sectorKey && sectorTime) {
+            this._overallBestSectors[sectorKey] = sectorTime;
+        }
     }
 
     /**

--- a/src/app/services/standings.service.ts
+++ b/src/app/services/standings.service.ts
@@ -293,7 +293,7 @@ export class StandingsService {
      * @param sectorKey - Sector to evaluate
      * @param sectorTime - Sector time in seconds
      */
-    _setFastestSector(sectorKey: string, sectorTime: number, ) {
+    _setFastestSector(sectorKey: string, sectorTime: number) {
         if (sectorKey && sectorTime) {
             this._overallBestSectors[sectorKey] = sectorTime;
         }


### PR DESCRIPTION
Github issue: https://github.com/KChadwick96/rFactor-2-Overlay/issues/47

Fixed sector 2 using sector 1 + 2 & Session best sectors are now session best instead of going off session best lap sectors.