### PR TITLE
Issue #68

### DIFF
--- a/src/app/components/default/tower/tower.component.html
+++ b/src/app/components/default/tower/tower.component.html
@@ -26,7 +26,7 @@
             </span>
             <span *ngIf="entry.position > 1">
                 <span *ngIf="entry.lapsBehindLeader > 0">
-                    +{{entry.lapsBehindLeader }} Laps
+                    +{{entry.lapsBehindLeader }} {{entry.lapsBehindLeader != 1 ? 'Laps' : 'Lap'}}
                 </span>
                 <span *ngIf="entry.lapsBehindLeader == 0">
                     {{ entry.timeBehindLeader | secondsConvert:true }}
@@ -41,7 +41,7 @@
             </span>
             <span *ngIf="entry.position > 1">
                 <span *ngIf="entry.lapsBehindNext > 0">
-                    +{{entry.lapsBehindNext }} Laps
+                    +{{entry.lapsBehindNext }} {{entry.lapsBehindNext != 1 ? 'Laps' : 'Lap'}}
                 </span>
                 <span *ngIf="entry.lapsBehindNext == 0">
                     {{ entry.timeBehindNext | secondsConvert:true }}


### PR DESCRIPTION
Remove 's' from Laps when only 1 Lap down

Github issue: https://github.com/KChadwick96/rFactor-2-Overlay/issues/68

Tower was showing '+1 Laps' when it should really have been saying '+1 Lap' so changed the tower to only show the s of laps if more than 1 lap down